### PR TITLE
added taco GET route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.idea/
+/node_modules/
+/package-lock.json

--- a/index.js
+++ b/index.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const app = express();
+
+// todo - sample taco payload for now
+const tacos = [
+    {
+        id:1,
+        name: "Al Pastor",
+        proteins: ["Pork"],
+        ingredients: [
+            "Pork",
+            "Pineapple",
+            "Cilantro",
+            "Onion"
+        ],
+        imageUrl:"https://images.pexels.com/photos/2338015/pexels-photo-2338015.jpeg?auto=compress&cs=tinysrgb&h=750&w=1260"
+    },
+    {
+        id:2,
+        name: "Carne Asada",
+        proteins: ["Beef"],
+        ingredients: [
+            "Beef",
+            "Cilantro",
+            "Onion"
+        ],
+        imageUrl:"https://images.pexels.com/photos/7613568/pexels-photo-7613568.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260"
+    }
+]
+
+app.get('/', function (req, res) {
+    res.send("hello");
+});
+
+app.get('/tacos', function (req, res) {
+    res.send(tacos)
+})
+
+app.listen(3000);

--- a/package.json
+++ b/package.json
@@ -7,5 +7,11 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.17.1"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.12"
+  }
 }


### PR DESCRIPTION
## Notes

- Added sample skeleton for Express.
- Added route for GET `/tacos` which will return all tacos.

## Testing
- run `npm install` and make sure you also have `nodemon` installed globally `npm install -g nodemon`
- then to run it `nodemon index.js`
- then go to `localhost:3000/tacos` in your browser, postman, or insomnia


/closes #1 